### PR TITLE
Change level for "Reporting span" message to DEBUG

### DIFF
--- a/lightstep/recorder.py
+++ b/lightstep/recorder.py
@@ -58,7 +58,8 @@ class LoggingRecorder(SpanRecorder):
                 else:
                     event = log.event
             logs.append(ttypes.LogRecord(stable_name= event, payload_json= log.payload))
-        logging.warn('Reporting span %s \n with logs %s', _pretty_span(span), _pretty_logs(logs))
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            logging.debug('Reporting span %s \n with logs %s', _pretty_span(span), _pretty_logs(logs))
 
     def flush(self):
         return True


### PR DESCRIPTION
This library is really chatty, creating a few line of logs for every
event, even in prod. This changes the level to DEBUG, and does not call
on `_pretty_span` and `_pretty_logs` if the output is not required (not
having the `if` there caused them to be called even if logging level was
greater than WARN).