### PR TITLE
address some critical correctness issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 
 lint:
 	pylint -r n --disable=invalid-name,global-statement,bare-except \
-		lightstep/instrument.py lightstep/constants.py lightstep/connection.py
+		lightstep/tracer.py lightstep/constants.py lightstep/recorder.py
 
 docs:
 	cd docs && make html

--- a/lightstep/recorder.py
+++ b/lightstep/recorder.py
@@ -74,7 +74,10 @@ class LoggingRecorder(SpanRecorder):
                     event = log.event[:constants.MAX_LOG_LEN]
                 else:
                     event = log.event
-            logs.append(ttypes.LogRecord(stable_name=event, payload_json=log.payload))
+            logs.append(ttypes.LogRecord(
+                timestamp_micros=long(util._time_to_micros(log.timestamp)),
+                stable_name=event,
+                payload_json=log.payload))
         logging.warn('Reporting span %s \n with logs %s', _pretty_span(span), _pretty_logs(logs))
 
     def flush(self):

--- a/lightstep/tracer.py
+++ b/lightstep/tracer.py
@@ -20,8 +20,7 @@ import sys
 import os
 
 import opentracing
-
-from .basictracer import BasicTracer
+from basictracer import BasicTracer
 
 from .recorder import Recorder, LoggingRecorder
 

--- a/lightstep/tracer.py
+++ b/lightstep/tracer.py
@@ -8,23 +8,9 @@ See the API definition for comments.
 """
 from __future__ import absolute_import
 
-
-import copy
-import json
-import threading
-import time
-import traceback
-import urllib
-import warnings
-import sys
-import os
-
-import opentracing
 from basictracer import BasicTracer
 
 from .recorder import Recorder, LoggingRecorder
-
-
 
 _TRACER_STATE_PREFIX = "ot-tracer-"
 _BAGGAGE_PREFIX = "ot-baggage-"

--- a/tests/runtime_test.py
+++ b/tests/runtime_test.py
@@ -5,7 +5,7 @@ import warnings
 import jsonpickle
 
 import lightstep.constants
-import lightstep.reporter
+import lightstep.recorder
 import lightstep.tracer
 import lightstep.instrument
 from lightstep.crouton import ttypes
@@ -269,25 +269,6 @@ class RuntimeTest(unittest.TestCase):
         self._check_span_payload({'A': 123, 'B' :d}, '{"A": 123, "B": {"one": 1, "three": 3, "two": 2}}')
         self._check_span_payload({'A': set([1, 2, 2])}, '{"A":[1,2]}')
 
-    # def test_readme_example(self):
-    #     # Artificial data for the example
-    #     self.mock_connection.clear()
-    #     runtime = self.create_test_runtime()
-    #     span = runtime._add_span(ttypes.SpanRecord(span_name='test_span'))
-    #     eventName='post_shared'
-    #     eventCount=510
-    #     # Sigh: testing a one element set here since it's not trivial to ensure
-    #     # a deterministic order to the set's json encode -> decode roundtrip.
-    #     eventData={'post_title':'Ski Video', 'tags': set(['snow'])}
-
-    #     span.infof('Event type %s occurred %d times', eventName, eventCount, payload=eventData)
-
-    #     span.end()
-    #     self.assertTrue(runtime.flush(self.mock_connection))
-    #     recorded_payload = self.mock_connection.reports[0].log_records[0].payload_json
-    #     self.check_payload(recorded_payload, '{"arguments": ["post_shared", 510], "payload": {"post_title": "Ski Video", "tags": ["snow"]}}', False)
-
-
     def test_new_style_object_payload(self):
         self.log_payload(NewStyleDummyObject())
         self.check_payload('{"bool_payload": true, "char_payload": "a", '
@@ -340,42 +321,6 @@ class RuntimeTest(unittest.TestCase):
         self.assertEqual(log.level, 'I')
         #self.check_payload(log.payload_json, '{"arguments": ["John", "Smith"], "payload": "Info"}')
         self.assertEqual(log.span_guid, span_record.span_guid)
-
-    # def test_span_warnf(self):
-    #     runtime = self.create_test_runtime()
-    #     span = runtime._add_span(ttypes.SpanRecord(span_name='Test Span Warnf')
-    #     span.warnf('Hi there %s %s', 'John', 'Smith', payload='Warn')
-    #     span.end()
-    #     self.assertTrue(runtime.flush(self.mock_connection))
-
-    #     report_span = self.mock_connection.reports[0].span_records[0]
-    #     self.assertTrue(report_span.span_name == 'Test Span Warnf',
-    #                     'Incorrect Span')
-
-    #     log = self.mock_connection.reports[0].log_records[0]
-    #     self.assertTrue(log.stable_name == 'Hi there John Smith',
-    #                     'Incorrect Log')
-    #     self.assertTrue(log.level == 'W', 'Incorrect Level')
-    #     self.check_payload(log.payload_json, '{"payload": "Warn", "arguments": ["John", "Smith"]}')
-    #     self.assertTrue(log.span_guid == report_span.span_guid)
-
-    # def test_span_errorf(self):
-    #     runtime = self.create_test_runtime()
-    #     span = runtime._add_span(ttypes.SpanRecord(span_name='Test Span Errorf')
-    #     span.errorf('Hi there %s %s', 'John', 'Smith', payload='Error')
-    #     span.end()
-    #     self.assertTrue(runtime.flush(self.mock_connection))
-
-    #     report_span = self.mock_connection.reports[0].span_records[0]
-    #     self.assertTrue(report_span.span_name == 'Test Span Errorf',
-    #                     'Incorrect Span')
-
-    #     log = self.mock_connection.reports[0].log_records[0]
-    #     self.assertTrue(log.stable_name == 'Hi there John Smith',
-    #                     'Incorrect Log')
-    #     self.assertTrue(log.level == 'E', 'Incorrect Level')
-    #     self.check_payload(log.payload_json, '{"arguments": ["John", "Smith"], "payload": "Error"}')
-    #     self.assertTrue(log.span_guid == report_span.span_guid)
 
     def test_span_as_context_manager(self):
         """ Tests that, within a span as a context manager, exceptions are logged and re-raised.


### PR DESCRIPTION
Fixes the following:
- start timestamps were in 1970 (seconds vs microseconds)
- previously ignored the youngest timestamp from the basictracer SpanRecord and hardcoded `now`
- previously ignored log timestamps (which meant they didn't show up in the UI among other things)
- previously imported things like `basictracer` from the local dir rather than via system imports (a la `pip`)
- Makefile referenced removed/renamed files
- a bunch of minor stuff (comments, lint errors, etc)

Does not fix:
- the unittests, though I did run the examples manually and verified correctness manually