### PR TITLE
Allow the user to disable the binary format import

### DIFF
--- a/lightstep/recorder.py
+++ b/lightstep/recorder.py
@@ -29,8 +29,8 @@ from . import constants, version as cruntime_version, util, connection as conn
 
 class Recorder(SpanRecorder):
     """Recorder records and reports a BasicSpan to LightStep."""
-    def __init__(self, *args, **kwargs):
-        self.runtime = Runtime(*args, **kwargs)
+    def __init__(self, **kwargs):
+        self.runtime = Runtime(**kwargs)
 
     def record_span(self, span):
         """Per BasicSpan.record_span"""

--- a/lightstep/tracer.py
+++ b/lightstep/tracer.py
@@ -59,6 +59,8 @@ class _LightstepTracer(BasicTracer):
         self.register_propagator(Format.TEXT_MAP, TextPropagator())
         self.register_propagator(Format.HTTP_HEADERS, TextPropagator())
         if enable_binary_format:
+            # We do this import lazily because protobuf versioning issues
+            # can cause process-level failure at import time.
             from basictracer.binary_propagator import BinaryPropagator
             self.register_propagator(Format.BINARY, BinaryPropagator())
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     license='',
     install_requires=['thrift==0.9.2',
                       'jsonpickle',
-                      'basictracer==2.0.0.dev3',
+                      'basictracer==2.0.1.dev1',
                       'opentracing==2.0.0.dev3'],
     tests_require=['sphinx',
                    'sphinx-epytext'],


### PR DESCRIPTION
... and thus disable the protobuf runtime dependency which can cause problems when there are other versions of the protobuf lib around.

See https://github.com/opentracing/basictracer-python/pull/10.