### PR TITLE
Bc/reporting robustness

### DIFF
--- a/examples/nontrivial/main.py
+++ b/examples/nontrivial/main.py
@@ -1,0 +1,99 @@
+"""Complex example
+"""
+import argparse
+import contextlib
+import sys
+import time
+import threading
+import random
+
+# Uncomment to test against the local copy
+import os
+sys.path.insert(1, os.path.dirname(os.path.realpath(__file__)) + '/../..')
+
+import opentracing
+import lightstep.tracer
+
+def sleep_dot():
+    """Short sleep and writes a dot to the STDOUT.
+    """
+    time.sleep(0.05)
+    sys.stdout.write('.')
+    sys.stdout.flush()
+
+def add_spans():
+    """Calls the opentracing API, doesn't use any LightStep-specific code.
+    """
+    with opentracing.tracer.start_span(operation_name='trivial/initial_request') as parent_span:
+        parent_span.set_tag('url', 'localhost')
+        parent_span.log_event('All good here!', payload={'N': 42, 'pi': 3.14, 'abc': 'xyz'})
+        parent_span.set_tag('span_type', 'parent')
+        parent_span.set_baggage_item('checked', 'baggage')
+
+        rng = random.SystemRandom()
+        for i in range(50):
+            time.sleep(rng.random() * 0.2)
+            sys.stdout.write('.')
+            sys.stdout.flush()
+
+            # This is how you would represent starting work locally.
+            with opentracing.start_child_span(parent_span, operation_name='trivial/child_request') as child_span:
+                child_span.log_event('Uh Oh!', payload={'error': True})
+                child_span.set_tag('span_type', 'child')
+
+                # Play with the propagation APIs... this is not IPC and thus not
+                # where they're intended to be used.
+                text_carrier = {}
+                opentracing.tracer.inject(child_span.context, opentracing.Format.TEXT_MAP, text_carrier)
+
+                span_context = opentracing.tracer.extract(opentracing.Format.TEXT_MAP, text_carrier)
+                with opentracing.tracer.start_span(
+                    'nontrivial/remote_span',
+                    child_of=span_context) as remote_span:
+                        remote_span.log_event('Remote!')
+                        remote_span.set_tag('span_type', 'remote')
+                        time.sleep(rng.random() * 0.1)
+
+                opentracing.tracer.flush()
+
+
+def lightstep_tracer_from_args():
+    """Initializes lightstep from the commandline args.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--token', help='Your LightStep access token.',
+                        default='{your_access_token}')
+    parser.add_argument('--host', help='The LightStep reporting service host to contact.',
+                        default='collector.lightstep.com')
+    parser.add_argument('--port', help='The LightStep reporting service port.',
+                        type=int, default=443)
+    parser.add_argument('--use_tls', help='Whether to use TLS for reporting',
+                        type=bool, default=True)
+    parser.add_argument('--group-name', help='The LightStep component name',
+                        default='python-examples-nontrivial')
+    args = parser.parse_args()
+
+    return lightstep.tracer.init_tracer(
+	    group_name=args.group_name,
+	    access_token=args.token,
+	    service_host=args.host,
+	    service_port=args.port,
+	    secure=args.use_tls)
+
+
+if __name__ == '__main__':
+    print 'Hello '
+
+    # Use LightStep's opentracing implementation
+    opentracing.tracer = lightstep_tracer_from_args()
+
+    for j in range(20):
+        threads = []
+        for i in range(64):
+            t = threading.Thread(target=add_spans)
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+        print '\n'
+    print '\nWorld!'

--- a/examples/nontrivial/main.py
+++ b/examples/nontrivial/main.py
@@ -1,4 +1,6 @@
-"""Complex example
+"""
+Synthetic example with high concurrency. Used primarily to stress test the
+library.
 """
 import argparse
 import contextlib

--- a/examples/nontrivial/main.py
+++ b/examples/nontrivial/main.py
@@ -9,7 +9,7 @@ import time
 import threading
 import random
 
-# Uncomment to test against the local copy
+# Comment out to test against the published copy
 import os
 sys.path.insert(1, os.path.dirname(os.path.realpath(__file__)) + '/../..')
 

--- a/lightstep/connection.py
+++ b/lightstep/connection.py
@@ -25,7 +25,7 @@ class _Connection(object):
         self._report_eof_count = 0
         self._report_exceptions_count = 0
         self._report_consecutive_errors = 0
-        self._report_socker_errors = 0
+        self._report_socket_errors = 0
 
     def open(self):
         """Establish HTTP connection to the server.
@@ -69,8 +69,8 @@ class _Connection(object):
             raise Exception('EOFError')
         except socket_error:
             self._report_consecutive_errors += 1
-            self._report_socker_errors += 1
-            raise Exception('socker_error')
+            self._report_socket_errors += 1
+            raise Exception('socket_error')
         finally:
             # In case the Thrift client has fallen into an unrecoverable state,
             # recreate the Thrift data structure if there are continued report

--- a/lightstep/connection.py
+++ b/lightstep/connection.py
@@ -1,10 +1,13 @@
 """ Connection class establishes HTTP connection with server.
     Utilized to send Thrift Report Requests.
 """
+import threading
 from thrift import Thrift
 from thrift.transport import THttpClient
 from thrift.protocol import TBinaryProtocol
 from .crouton import ReportingService
+
+CONSECUTIVE_ERRORS_BEFORE_RECONNECT = 100
 
 class _Connection(object):
     """Instances of _Connection are used to establish a connection to the
@@ -14,10 +17,14 @@ class _Connection(object):
     """
     def __init__(self, service_url):
         self._service_url = service_url
+        self._lock = threading.Lock()
         self._transport = None
         self._client = None
         self.ready = False
+        self._open_exceptions_count = 0
+        self._report_eof_count = 0
         self._report_exceptions_count = 0
+        self._report_consecutive_errors = 0
 
     def open(self):
         """Establish HTTP connection to the server.
@@ -25,15 +32,18 @@ class _Connection(object):
         Note: THttpClient also supports https and will use http/https according
         to the scheme in the URL it is given.
         """
+        self._lock.acquire()
         try:
             self._transport = THttpClient.THttpClient(self._service_url)
             self._transport.open()
             protocol = TBinaryProtocol.TBinaryProtocol(self._transport)
             self._client = ReportingService.Client(protocol)
         except Thrift.TException:
-            self._report_exceptions_count += 1
+            self._open_exceptions_count += 1
         else:
             self.ready = True
+        finally:
+            self._lock.release()
 
 
     def report(self, *args, **kwargs):
@@ -41,7 +51,28 @@ class _Connection(object):
         # Notice the annoying case change on the method name. I chose to stay
         # consistent with casing in this class vs staying consistent with the
         # casing of the pass-through method.
-        return self._client.Report(*args, **kwargs)
+        resp = None
+        self._lock.acquire()
+        try:
+            if self._client:
+                resp = self._client.Report(*args, **kwargs)
+                self._report_consecutive_errors = 0
+        except Thrift.TException:
+            self._report_consecutive_errors += 1
+            self._report_exceptions_count += 1
+        except EOFError:
+            self._report_consecutive_errors += 1
+            self._report_eof_count += 1
+        finally:
+            # In case the Thrift client has fallen into an unrecoverable state,
+            # recreate the Thrift data structure if there are continued report
+            # failures
+            if self._report_consecutive_errors == CONSECUTIVE_ERRORS_BEFORE_RECONNECT:
+                self._report_consecutive_errors = 0
+                self.ready = False
+            self._lock.release()
+
+        return resp
 
     def close(self):
         """Close HTTP connection to the server."""
@@ -49,4 +80,9 @@ class _Connection(object):
             return
         if self._client is None:
             return
-        self._transport.close()
+
+        self._lock.acquire()
+        try:
+            self._transport.close()
+        finally:
+            self._lock.release()

--- a/lightstep/connection.py
+++ b/lightstep/connection.py
@@ -7,7 +7,7 @@ from thrift.transport import THttpClient
 from thrift.protocol import TBinaryProtocol
 from .crouton import ReportingService
 
-CONSECUTIVE_ERRORS_BEFORE_RECONNECT = 100
+CONSECUTIVE_ERRORS_BEFORE_RECONNECT = 200
 
 class _Connection(object):
     """Instances of _Connection are used to establish a connection to the

--- a/lightstep/connection.py
+++ b/lightstep/connection.py
@@ -23,9 +23,9 @@ class _Connection(object):
         self.ready = False
         self._open_exceptions_count = 0
         self._report_eof_count = 0
+        self._report_socket_errors = 0
         self._report_exceptions_count = 0
         self._report_consecutive_errors = 0
-        self._report_socket_errors = 0
 
     def open(self):
         """Establish HTTP connection to the server.

--- a/lightstep/recorder.py
+++ b/lightstep/recorder.py
@@ -196,7 +196,7 @@ class Runtime(object):
         immediately sent to the host server.
 
         If connection is not specified, the report will sent to the server
-        passed in to __init__.  Note that custom connetions are currently used
+        passed in to __init__.  Note that custom connections are currently used
         for unit testing against a mocked connection.
 
         Returns whether the data was successfully flushed.

--- a/lightstep/recorder.py
+++ b/lightstep/recorder.py
@@ -250,7 +250,7 @@ class Runtime(object):
             # Return whether we sent any span data
             return len(report_request.span_records) > 0
 
-        except (Thrift.TException, socket_error):
+        except Exception:
             self._restore_spans(report_request.span_records)
             return False
 

--- a/tests/recorder_test.py
+++ b/tests/recorder_test.py
@@ -58,18 +58,6 @@ class RecorderTest(unittest.TestCase):
         """
         return lightstep.recorder.Recorder(**self.runtime_args)
 
-    # ---------------
-    # NO PARAM TESTS
-    # ---------------
-    def test_init_without_params(self):
-        # Won't be able to send logs and spans - but shouldn't crash
-        recorder = lightstep.recorder.Recorder()
-        recorder.record_span(self.dummy_basic_span(recorder, 123))
-        self.assertFalse(recorder.runtime.flush(),
-                         "Flush should have failed to reach backend")
-        self.assertFalse(recorder.runtime.shutdown(flush=True),
-                         "Shutdown's flush should have failed to reach backend.")
-
     # -------------
     # SHUTDOWN TESTS
     # -------------


### PR DESCRIPTION
## Summary

Improves the robustness of the client library with regards to the reporting:

**Thrift has shared state across Client objects**. The LightStep code previously created separate `Connection` objects for manual and automatic flushing. This was not thread-safe as, even though they were independent objects, it turns out Thrift has some shared state that could cause the `Report()` call to throw exceptions within the Thrift internals (usually manifested by objects unexpected being `None`). The Tracer now uses a single shared `Connection` and that object, as a consequence, now has a lock to protect against concurrent access to the Thrift structures.

A few smaller changes:

* Catch and count exception on the Thrift Report call
* Reinitialize all the Thrift objects on repeated failures
* Handle the case where the report response is `None`
* Drop a unit test that wasn't testing any useful (and now fails with the reconnect logic)