### PR TITLE
Support new basictracer-py LogData

### DIFF
--- a/lightstep/recorder.py
+++ b/lightstep/recorder.py
@@ -52,16 +52,16 @@ class LoggingRecorder(SpanRecorder):
         logs = []
         for log in span.logs:
             event = ""
-            if len(log.event) > 0:
+            if len(log.key_values["event"]) > 0:
                 # Don't allow for arbitrarily long log messages.
-                if sys.getsizeof(log.event) > constants.MAX_LOG_MEMORY:
-                    event = log.event[:constants.MAX_LOG_LEN]
+                if sys.getsizeof(log.key_values["event"]) > constants.MAX_LOG_MEMORY:
+                    event = log.key_values["event"][:constants.MAX_LOG_LEN]
                 else:
-                    event = log.event
+                    event = log.key_values["event"]
             logs.append(ttypes.LogRecord(
                 timestamp_micros=long(util._time_to_micros(log.timestamp)),
                 stable_name=event,
-                payload_json=log.payload))
+                payload_json=log.key_values["payload"]))
         logging.info(
             'Reporting span %s \n with logs %s',
             self._pretty_span(span),
@@ -321,16 +321,16 @@ class Runtime(object):
 
         for log in span.logs:
             event = ""
-            if len(log.event) > 0:
+            if len(log.key_values["event"]) > 0:
                 # Don't allow for arbitrarily long log messages.
-                if sys.getsizeof(log.event) > constants.MAX_LOG_MEMORY:
-                    event = log.event[:constants.MAX_LOG_LEN]
+                if sys.getsizeof(log.key_values["event"]) > constants.MAX_LOG_MEMORY:
+                    event = log.key_values["event"][:constants.MAX_LOG_LEN]
                 else:
-                    event = log.event
+                    event = log.key_values["event"]
             span_record.log_records.append(ttypes.LogRecord(
                 timestamp_micros=long(util._time_to_micros(log.timestamp)),
                 stable_name=event,
-                payload_json=log.payload))
+                payload_json=log.key_values["payload"]))
 
         with self._mutex:
             if len(self._span_records) < self._max_span_records:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lightstep',
-    version='2.1.11',
+    version='2.2.0',
     description='LightStep Python OpenTracing Implementation',
     long_description='',
     author='LightStep',
@@ -10,15 +10,14 @@ setup(
     install_requires=['thrift==0.9.2',
                       'jsonpickle',
                       'pytest',
-                      'basictracer>=2.1,<2.2',
-                      'opentracing>=1.1,<1.2'],
+                      'basictracer>=2.2,<2.3',
+                      'opentracing>=1.2,<1.3'],
     tests_require=['sphinx',
                    'sphinx-epytext'],
 
     classifiers=[
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
-        # 'Programming Language :: Python :: 3',
     ],
 
     keywords=[ 'opentracing', 'lightstep', 'traceguide', 'tracing', 'microservices', 'distributed' ],


### PR DESCRIPTION
Note that this does not offer full key-value logging support; just keeps abreast of BasicTracer changes. The endgame is to support arbitrary keys and values, but that change should come along with the gRPC migration.