### PR TITLE
Don't crash given unicode strings

### DIFF
--- a/examples/trivial/main.py
+++ b/examples/trivial/main.py
@@ -26,6 +26,7 @@ def add_spans():
         parent_span.log_kv({'foo': 'bar'})
         parent_span.set_tag('span_type', 'parent')
         parent_span.set_tag('int_tag', 5)
+        parent_span.set_tag('unicode_val', u'non-ascii: \u200b')
         parent_span.set_tag('bool_tag', True)
         parent_span.set_baggage_item('checked', 'baggage')
         sleep_dot()
@@ -72,6 +73,7 @@ def lightstep_tracer_from_args():
             access_token=args.token,
             collector_host=args.host,
             collector_port=args.port,
+            verbosity=1,
             collector_encryption=('tls' if args.use_tls else 'none'))
 
 

--- a/lightstep/recorder.py
+++ b/lightstep/recorder.py
@@ -76,13 +76,13 @@ class Recorder(SpanRecorder):
             'lightstep.guid': util._id_to_hex(self.guid),
             })
         # Convert tracer_tags to a list of KeyValue pairs.
-        runtime_attrs = [ttypes.KeyValue(k, str(v)) for (k, v) in tracer_tags.iteritems()]
+        runtime_attrs = [ttypes.KeyValue(k, util._coerce_str(v)) for (k, v) in tracer_tags.iteritems()]
 
         # Thrift is picky about the types being correct, so we're explicit here
         self._runtime = ttypes.Runtime(
                 util._id_to_hex(self.guid),
                 long(timestamp),
-                str(component_name),
+                util._coerce_str(component_name),
                 runtime_attrs)
         self._finest("Initialized with Tracer runtime: %s", (self._runtime,))
         secure = collector_encryption != 'none'  # the default is 'tls'
@@ -141,7 +141,7 @@ class Recorder(SpanRecorder):
             trace_guid=util._id_to_hex(span.context.trace_id),
             span_guid=util._id_to_hex(span.context.span_id),
             runtime_guid=util._id_to_hex(self.guid),
-            span_name=str(span.operation_name),
+            span_name=util._coerce_str(span.operation_name),
             join_ids=[],
             oldest_micros=long(util._time_to_micros(span.start_time)),
             youngest_micros=long(util._time_to_micros(span.start_time + span.duration)),
@@ -157,9 +157,9 @@ class Recorder(SpanRecorder):
         if span.tags:
             for key in span.tags:
                 if key[:len(constants.JOIN_ID_TAG_PREFIX)] == constants.JOIN_ID_TAG_PREFIX:
-                    span_record.join_ids.append(ttypes.TraceJoinId(key, str(span.tags[key])))
+                    span_record.join_ids.append(ttypes.TraceJoinId(key, util._coerce_str(span.tags[key])))
                 else:
-                    span_record.attributes.append(ttypes.KeyValue(key, str(span.tags[key])))
+                    span_record.attributes.append(ttypes.KeyValue(key, util._coerce_str(span.tags[key])))
 
         for log in span.logs:
             event = log.key_values.get('event') or ''

--- a/lightstep/util.py
+++ b/lightstep/util.py
@@ -51,3 +51,14 @@ def _merge_dicts(*dict_args):
             result.update(dictionary)
     return result if result else None
 
+def _coerce_str(str_or_unicode):
+    if isinstance(str_or_unicode, str):
+        return str_or_unicode
+    elif isinstance(str_or_unicode, unicode):
+        return str_or_unicode.encode('utf-8', 'replace')
+    else:
+        try:
+            return str(str_or_unicode)
+        except Exception:
+            # Never let these errors bubble up
+            return '(encoding error)'

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -18,6 +18,12 @@ class UtilTest(unittest.TestCase):
         self.assertEqual({'a': 'b', 'c': 'd', 'e': 'f'}, util._merge_dicts({}, {'a': 'b','c': 'd'}, None, {'e': 'f'}))
 
         self.assertEqual({'a': 'c', 'e': 'f'}, util._merge_dicts({'a': 'b', 'e': 'f'}, {'a': 'c'}))
+    
+    def test_coerce_str(self):
+        self.assertEqual('str', util._coerce_str('str'))
+        self.assertEqual('unicode', util._coerce_str(u'unicode'))
+        self.assertEqual('hard unicode char: \xe2\x80\x8b', util._coerce_str(u'hard unicode char: \u200b'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Instead, re-encode them as UTF-8 `str`s.

We also add a last-ditch attempt to not-raise exceptions, though that shouldn't ever be needed.