### PR TITLE
Move pytest from install_requires to tests_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ setup(
     license='',
     install_requires=['thrift==0.9.2',
                       'jsonpickle',
-                      'pytest',
                       'basictracer>=2.2,<2.3'],
-    tests_require=['sphinx',
+    tests_require=['pytest',
+                   'sphinx',
                    'sphinx-epytext'],
 
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py26, py27
 
 
 [testenv]
+deps =
+    pytest
 commands =
-    python tests/opentracing_compatibility_test.py
-    python tests/recorder_test.py
-    python tests/util_test.py
+    python -m pytest {posargs:tests}


### PR DESCRIPTION
As it was, anyone who `pip install`ed this package also got pytest. This isn't the best. Also changed the tests to actually _use_ pytest.