### PR TITLE
Remove support for Python 2.6

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
 dependencies:
     override:
         - pip install tox tox-pyenv
-        - pyenv local 2.7.10 2.6.8
+        - pyenv local 2.7.10
 test:
     override:
         - make test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 ; commented out py34 testing due to current thrift issues with python3
 ; envlist = py26, py27, py34
-envlist = py26, py27
+envlist = py27
 
 
 [testenv]


### PR DESCRIPTION
Circle CI ubuntu 14.04 no longer supports any 2.6 python versions.