### PR TITLE
Make CircleCI install Python 2.7 and 3.4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
-    python:
-        version: 2.7.10
+    post:
+        - pyenv global 2.7.10 3.4.4
 # The 'override' is needed to test multiple versions within tox
 # See https://github.com/samstav/circleci-python-sandbox/issues/1#issuecomment-142641082
 dependencies:


### PR DESCRIPTION
According to https://circleci.com/docs/1.0/language-python/ this is the way to test against multiple versions of Python.

The latest commit in `master` breaks because we had forgotten to add a dependency to Python 3.4 ;) 

@frenchfrywpepper @katiabazzi 

PS - Is it possible to automatically run CircleCI for PRs?