### PR TITLE
Migrate our CircleCI config to v2.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,25 @@
+version: 2
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test-2.7
+      - test-3.4
+jobs:
+  test-2.7: &test-template
+    environment:
+      PYTHON_ENV: py27
+    docker:
+      - image: circleci/python:2.7-jessie
+    steps:
+      - checkout
+      - run: sudo pip install tox virtualenv
+      - run: virtualenv env && echo "source env/bin/activate" >> $BASH_ENV
+      - run: make bootstrap
+      - run: tox -e $PYTHON_ENV
+  test-3.4:
+    <<: *test-template
+    environment:
+      PYTHON_ENV: py34
+    docker:
+      - image: circleci/python:3.4-jessie


### PR DESCRIPTION
1.0 support is going to be dumped soon.
Also, make it work with both Python 2.7
and 3.4 properly.

cc @joeblubaugh ;)