### PR TITLE
Calculate and set seconds and nanos for Span's Timestamp proto

### DIFF
--- a/lightstep/constants.py
+++ b/lightstep/constants.py
@@ -26,6 +26,7 @@ JSON_WARNING = True
 
 # utils constants
 SECONDS_TO_MICRO = 1000000
+SECONDS_TO_NANOS = 1000000000
 
 # Recorder constants
 MAX_LOG_MEMORY = 1024

--- a/lightstep/http_converter.py
+++ b/lightstep/http_converter.py
@@ -1,4 +1,5 @@
 from lightstep.collector_pb2 import Auth, ReportRequest, Span, Reporter, KeyValue, Reference, SpanContext
+from lightstep.constants import SECONDS_TO_NANOS
 from lightstep.converter import Converter
 from . import util
 from . import version as tracer_version
@@ -39,9 +40,11 @@ class HttpConverter(Converter):
     def create_span_record(self, span, guid):
         span_context = SpanContext(trace_id=span.context.trace_id,
                                    span_id=span.context.span_id)
+        seconds = int(span.start_time)
+        nanos = int((span.start_time - seconds) * SECONDS_TO_NANOS)
         span_record = Span(span_context=span_context,
                            operation_name=util._coerce_str(span.operation_name),
-                           start_timestamp=Timestamp(seconds=int(span.start_time)),
+                           start_timestamp=Timestamp(seconds=seconds, nanos=nanos),
                            duration_micros=int(util._time_to_micros(span.duration)))
         if span.parent_id is not None:
             reference = span_record.references.add()


### PR DESCRIPTION
As discussed in https://github.com/lightstep/lightstep-tracer-python/issues/56 this PR looks to provide better span timing resolution by providing the `seconds` and `nanos` (fraction of the second) value for the Timestamp proto object. 

I wasn't sure about your contribution policy so I have not updated the VERSION file in the repo, looking at previous commits to master it appears you usually increment this separately in another commit. Happy to include that in this PR if required though.