### PR TITLE
Adds conformance test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,6 @@ proto:
 	protoc --proto_path "$(PWD)/../googleapis:$(PWD)/../lightstep-tracer-common/" \
 		--python_out="$(PWD)/lightstep" \
 		collector.proto
+
+conformance: build cloudbuild.yaml
+	gcloud builds submit --config cloudbuild.yaml .

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,9 @@
+steps:
+  - name: 'gcr.io/cloud-builders/git'
+    args: ['clone', 'https://github.com/lightstep/conformance.git']
+  - name: 'gcr.io/cloud-builders/go:debian'
+    args: ['install', 'github.com/lightstep/conformance/runner']
+    env: ['PROJECT_ROOT=github.com/lightstep']
+  - name: 'python:2'
+    entrypoint: 'sh'
+    args: ['-c', 'pip install -r requirements.txt && gopath/bin/runner python tests/conformance/conformance_client.py']

--- a/tests/conformance/conformance_client.py
+++ b/tests/conformance/conformance_client.py
@@ -1,0 +1,36 @@
+import json
+import sys
+import base64
+
+import lightstep.tracer
+from lightstep.propagation import LightStepFormat
+from opentracing import Format
+
+
+def main():
+    tracer = lightstep.Tracer(periodic_flush_seconds=0, collector_host='localhost')
+    body = json.load(sys.stdin)
+
+    text_context = extract_http_headers(body, tracer)
+    text_carrier = {}
+    tracer.inject(text_context, Format.TEXT_MAP, text_carrier)
+
+    binary_context = extract_binary(body, tracer)
+    binary_carrier = bytearray()
+    tracer.inject(binary_context, LightStepFormat.LIGHTSTEP_BINARY, binary_carrier)
+    json.dump({"text_map": text_carrier, "binary": base64.b64encode(binary_carrier)}, sys.stdout)
+
+
+
+def extract_http_headers(body, tracer):
+    span_context = tracer.extract(Format.TEXT_MAP, body['text_map'])
+    return span_context
+
+def extract_binary(body, tracer):
+    bin64 = bytearray(base64.b64decode(body['binary']))
+    span_context = tracer.extract(LightStepFormat.LIGHTSTEP_BINARY, bin64)
+    return span_context
+
+if __name__ == "__main__":
+    # execute only if run as a script
+    main()


### PR DESCRIPTION
We have implemented a conformance test which validates a tracer's inject/extract carrier format. There's is a conformance harness that sends a set of carriers to a client (written in python here)  and reads the clients response from stdout.

The client reads a JSON blob from stdin, extracts the span context for each carrier format, then injects the span contexts into a new JSON blob and sends that over stdout. 

Google Cloud Build is being used for CI, to run the cloudbuild.yaml file locally see https://cloud.google.com/cloud-build/docs/build-debug-locally