### PR TITLE
Ignore error statuses in Thrift client response path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,16 +67,6 @@ test37: build
 test: build
 	tox
 
-
-# LightStep-specific: rebuilds the LightStep thrift protocol files.  Assumes
-# the command is run within the LightStep development environment (i.e. the
-# MONO_REPO environment variable is set).
-thrift:
-	docker run -v "$(PWD)/lightstep:/out" -v "$(MONO_REPO)/go/src/github.com/lightstep/common-go:/data" --rm thrift:0.10.0 \
-		thrift -r --gen py -out /out /data/crouton.thrift
-	python-modernize -w $(PWD)/lightstep/crouton/
-	rm -rf lightstep/crouton/ReportingService-remote
-
 # LightStep-specific: rebuilds the LightStep protobuf files.
 proto:
 	protoc --proto_path "$(PWD)/../googleapis:$(PWD)/../lightstep-tracer-common/" \

--- a/lightstep/crouton/ReportingService.py
+++ b/lightstep/crouton/ReportingService.py
@@ -55,6 +55,8 @@ class Client(Iface):
 
   def recv_Report(self):
     iprot = self._iprot
+    if iprot.trans.code != 200:
+      raise TApplicationException(TApplicationException, "Report failed: Received a server error")
     (fname, mtype, rseqid) = iprot.readMessageBegin()
     if mtype == TMessageType.EXCEPTION:
       x = TApplicationException()


### PR DESCRIPTION
When the Satellite is backed by an ELB/ALB/other that transmits 5xx/4xx with some sort of non-Thrift, non-binary message, the Thrift client will attempt to parse this message as binary and fail. This process causes a 10x memory spike on the python process which can lead to erroneous OOM indicators.

This PR also removes the make thrift target, as we are editing generated files in this PR.