### PR TITLE
Add performance regression tests and performance reports to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           path: ~/benchmark/logs
           destination: logs
 
-  make_other_graphs:
+  make_dropped_graphs:
     docker:
       - image: circleci/python:3.7.4
     working_directory: ~/repo
@@ -144,7 +144,41 @@ jobs:
       - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
       - run: python ~/benchmark/dropped_graphs.py python
+      - store_artifacts:
+          path: ~/benchmark/graphs
+          destination: graphs
+      - store_artifacts:
+          path: ~/benchmark/logs
+          destination: logs
+
+  make_memory_graphs:
+    docker:
+      - image: circleci/python:3.7.4
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
+      - run: ~/benchmark/scripts/ci_setup.sh
+      - run: sudo pip install -e ~/repo
       - run: python ~/benchmark/memory_graphs.py python
+      - store_artifacts:
+          path: ~/benchmark/graphs
+          destination: graphs
+      - store_artifacts:
+          path: ~/benchmark/logs
+          destination: logs
+
+  make_disconnect_graphs:
+    docker:
+      - image: circleci/python:3.7.4
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
+      - run: ~/benchmark/scripts/ci_setup.sh
+      - run: sudo pip install -e ~/repo
       - run: python ~/benchmark/disconnect_graphs.py python
       - store_artifacts:
           path: ~/benchmark/graphs
@@ -165,7 +199,13 @@ workflows:
       - regression_test
       - approve_make_graphs:
           type: approval
-      - make_other_graphs:
+      - make_dropped_graphs:
+          requires:
+            - approve_make_graphs
+      - make_memory_graphs:
+          requires:
+            - approve_make_graphs
+      - make_disconnect_graphs:
           requires:
             - approve_make_graphs
       - make_cpu_graphs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
       - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
-      - run: pytest -s --client_name python ~/benchmark/test_client.py
+      - run: pytest -s --client_name python ~/benchmark/regression_tests.py
       - store_artifacts:
           path: logs
           destination: logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,12 +106,14 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: git clone https://github.com/lightstep/lightstep-benchmarks.git ~/benchmark
-      - run: ~/benchmark/scripts/ci_setup.sh
+      - run: cd ~; ~/repo/ci/clone_lightstep_benchmarks.sh
+      - run: ~/lightstep-benchmarks/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
-      - run: pytest -s --client_name python ~/benchmark/regression_tests.py
+      - run: |
+          cd ~/lightstep-benchmarks/
+          pytest -s --client_name python regression_tests.py
       - store_artifacts:
-          path: logs
+          path: ~/lightstep-benchmarks/logs
           destination: logs
 
   make_cpu_graphs:
@@ -120,15 +122,15 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: git clone https://github.com/lightstep/lightstep-benchmarks.git ~/benchmark
-      - run: ~/benchmark/scripts/ci_setup.sh
+      - run: cd ~; ~/repo/ci/clone_lightstep_benchmarks.sh
+      - run: ~/lightstep-benchmarks/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
-      - run: python ~/benchmark/cpu_graphs.py python --runtime 10 --trials 10
+      - run: python ~/lightstep-benchmarks/cpu_graphs.py python --runtime 10 --trials 10
       - store_artifacts:
-          path: ~/benchmark/graphs
+          path: ~/lightstep-benchmarks/graphs
           destination: graphs
       - store_artifacts:
-          path: ~/benchmark/logs
+          path: ~/lightstep-benchmarks/logs
           destination: logs
 
   make_dropped_graphs:
@@ -137,15 +139,15 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: git clone https://github.com/lightstep/lightstep-benchmarks.git ~/benchmark
-      - run: ~/benchmark/scripts/ci_setup.sh
+      - run: cd ~; ~/repo/ci/clone_lightstep_benchmarks.sh
+      - run: ~/lightstep-benchmarks/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
-      - run: python ~/benchmark/dropped_graphs.py python
+      - run: python ~/lightstep-benchmarks/dropped_graphs.py python
       - store_artifacts:
-          path: ~/benchmark/graphs
+          path: ~/lightstep-benchmarks/graphs
           destination: graphs
       - store_artifacts:
-          path: ~/benchmark/logs
+          path: ~/lightstep-benchmarks/logs
           destination: logs
 
   make_memory_graphs:
@@ -154,15 +156,15 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: git clone https://github.com/lightstep/lightstep-benchmarks.git ~/benchmark
-      - run: ~/benchmark/scripts/ci_setup.sh
+      - run: cd ~; ~/repo/ci/clone_lightstep_benchmarks.sh
+      - run: ~/lightstep-benchmarks/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
-      - run: python ~/benchmark/memory_graphs.py python
+      - run: python ~/lightstep-benchmarks/memory_graphs.py python
       - store_artifacts:
-          path: ~/benchmark/graphs
+          path: ~/lightstep-benchmarks/graphs
           destination: graphs
       - store_artifacts:
-          path: ~/benchmark/logs
+          path: ~/lightstep-benchmarks/logs
           destination: logs
 
   make_disconnect_graphs:
@@ -171,15 +173,15 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - run: git clone https://github.com/lightstep/lightstep-benchmarks.git ~/benchmark
-      - run: ~/benchmark/scripts/ci_setup.sh
+      - run: cd ~; ~/repo/ci/clone_lightstep_benchmarks.sh
+      - run: ~/lightstep-benchmarks/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
-      - run: python ~/benchmark/disconnect_graphs.py python
+      - run: python ~/lightstep-benchmarks/disconnect_graphs.py python
       - store_artifacts:
-          path: ~/benchmark/graphs
+          path: ~/lightstep-benchmarks/graphs
           destination: graphs
       - store_artifacts:
-          path: ~/benchmark/logs
+          path: ~/lightstep-benchmarks/logs
           destination: logs
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,18 +7,18 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-    - image: circleci/python:2.7
+      - image: circleci/python:2.7
     steps:
-    - checkout
-    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    - run: sudo pip install tox
-    - run: make test27
-    - store_test_results:
-        path: /tmp/circleci-test-results
-    - store_artifacts:
-        path: /tmp/circleci-artifacts
-    - store_artifacts:
-        path: /tmp/circleci-test-results
+      - checkout
+      - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+      - run: sudo pip install tox
+      - run: make test27
+      - store_test_results:
+          path: /tmp/circleci-test-results
+      - store_artifacts:
+          path: /tmp/circleci-artifacts
+      - store_artifacts:
+          path: /tmp/circleci-test-results
 
   test-python3.4:
     working_directory: ~/lightstep/lightstep-tracer-python
@@ -27,18 +27,18 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-    - image: circleci/python:3.4
+      - image: circleci/python:3.4
     steps:
-    - checkout
-    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    - run: sudo pip install tox
-    - run: make test34
-    - store_test_results:
-        path: /tmp/circleci-test-results
-    - store_artifacts:
-        path: /tmp/circleci-artifacts
-    - store_artifacts:
-        path: /tmp/circleci-test-results
+      - checkout
+      - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+      - run: sudo pip install tox
+      - run: make test34
+      - store_test_results:
+          path: /tmp/circleci-test-results
+      - store_artifacts:
+          path: /tmp/circleci-artifacts
+      - store_artifacts:
+          path: /tmp/circleci-test-results
 
   test-python3.5:
     working_directory: ~/lightstep/lightstep-tracer-python
@@ -47,18 +47,18 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-    - image: circleci/python:3.5
+      - image: circleci/python:3.5
     steps:
-    - checkout
-    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    - run: sudo pip install tox
-    - run: make test35
-    - store_test_results:
-        path: /tmp/circleci-test-results
-    - store_artifacts:
-        path: /tmp/circleci-artifacts
-    - store_artifacts:
-        path: /tmp/circleci-test-results
+      - checkout
+      - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+      - run: sudo pip install tox
+      - run: make test35
+      - store_test_results:
+          path: /tmp/circleci-test-results
+      - store_artifacts:
+          path: /tmp/circleci-artifacts
+      - store_artifacts:
+          path: /tmp/circleci-test-results
 
   test-python3.6:
     working_directory: ~/lightstep/lightstep-tracer-python
@@ -67,18 +67,18 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-    - image: circleci/python:3.6
+      - image: circleci/python:3.6
     steps:
-    - checkout
-    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    - run: sudo pip install tox
-    - run: make test36
-    - store_test_results:
-        path: /tmp/circleci-test-results
-    - store_artifacts:
-        path: /tmp/circleci-artifacts
-    - store_artifacts:
-        path: /tmp/circleci-test-results
+      - checkout
+      - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+      - run: sudo pip install tox
+      - run: make test36
+      - store_test_results:
+          path: /tmp/circleci-test-results
+      - store_artifacts:
+          path: /tmp/circleci-artifacts
+      - store_artifacts:
+          path: /tmp/circleci-test-results
 
   test-python3.7:
     working_directory: ~/lightstep/lightstep-tracer-python
@@ -87,18 +87,58 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-    - image: circleci/python:3.7
+      - image: circleci/python:3.7
     steps:
-    - checkout
-    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    - run: sudo pip install tox
-    - run: make test37
-    - store_test_results:
-        path: /tmp/circleci-test-results
-    - store_artifacts:
-        path: /tmp/circleci-artifacts
-    - store_artifacts:
-        path: /tmp/circleci-test-results
+      - checkout
+      - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+      - run: sudo pip install tox
+      - run: make test37
+      - store_test_results:
+          path: /tmp/circleci-test-results
+      - store_artifacts:
+          path: /tmp/circleci-artifacts
+      - store_artifacts:
+          path: /tmp/circleci-test-results
+
+  regression_test:
+    docker:
+      - image: circleci/python:3.7.4
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/tracer-benchmark
+      - run: ~/tracer-benchmark/scripts/ci_setup.sh
+      # install the LS tracer
+      - run: sudo pip install -e ~/repo
+      - run: pytest --client_name python-cpp ~/tracer-benchmark/test_client.py
+      - store_artifacts:
+          path: logs
+          destination: logs
+
+  # make_graphs:
+  #   docker:
+  #     - image: circleci/python:3.7.4
+  #   working_directory: ~/repo
+  #
+  #   steps:
+  #     - run: cd ~; git clone https://github.com/isaaczinda/tracer-benchmark.git repo
+  #     - run: ./scripts/ci_setup.sh
+  #     - attach_workspace:
+  #         at: ~/plugin
+  #     - run: sudo pip install ~/plugin/*.whl
+  #     - run: mkdir graphs
+  #     - run: python cpu_graphs.py python-cpp --runtime 10 --trials 10
+  #     - run: python memory_graphs.py python-cpp
+  #     - run: python dropped_graphs.py python-cpp
+  #     - run: python disconnect_graphs.py python-cpp
+  #
+  #     - store_artifacts:
+  #         path: logs
+  #         destination: logs
+  #     - store_artifacts:
+  #         path: graphs
+  #         destination: graphs
 
 workflows:
   version: 2
@@ -109,3 +149,4 @@ workflows:
       - test-python3.5
       - test-python3.6
       - test-python3.7
+      - regression_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,6 @@ jobs:
       - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
       - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
-      - run: mkdir ~/benchmark/graphs
       - run: python ~/benchmark/cpu_graphs.py python --runtime 10 --trials 10
       - store_artifacts:
           path: ~/benchmark/graphs
@@ -144,7 +143,6 @@ jobs:
       - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
       - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
-      - run: mkdir ~/benchmark/graphs
       - run: python ~/benchmark/dropped_graphs.py python
       - run: python ~/benchmark/memory_graphs.py python
       - run: python ~/benchmark/disconnect_graphs.py python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,9 @@ jobs:
     docker:
       - image: circleci/python:3.7.4
     working_directory: ~/repo
-
     steps:
       - checkout
-      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
+      - run: git clone https://github.com/lightstep/lightstep-benchmarks.git ~/benchmark
       - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
       - run: pytest -s --client_name python ~/benchmark/regression_tests.py
@@ -119,10 +118,9 @@ jobs:
     docker:
       - image: circleci/python:3.7.4
     working_directory: ~/repo
-
     steps:
       - checkout
-      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
+      - run: git clone https://github.com/lightstep/lightstep-benchmarks.git ~/benchmark
       - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
       - run: python ~/benchmark/cpu_graphs.py python --runtime 10 --trials 10
@@ -137,10 +135,9 @@ jobs:
     docker:
       - image: circleci/python:3.7.4
     working_directory: ~/repo
-
     steps:
       - checkout
-      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
+      - run: git clone https://github.com/lightstep/lightstep-benchmarks.git ~/benchmark
       - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
       - run: python ~/benchmark/dropped_graphs.py python
@@ -155,10 +152,9 @@ jobs:
     docker:
       - image: circleci/python:3.7.4
     working_directory: ~/repo
-
     steps:
       - checkout
-      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
+      - run: git clone https://github.com/lightstep/lightstep-benchmarks.git ~/benchmark
       - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
       - run: python ~/benchmark/memory_graphs.py python
@@ -173,10 +169,9 @@ jobs:
     docker:
       - image: circleci/python:3.7.4
     working_directory: ~/repo
-
     steps:
       - checkout
-      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
+      - run: git clone https://github.com/lightstep/lightstep-benchmarks.git ~/benchmark
       - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
       - run: python ~/benchmark/disconnect_graphs.py python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,38 +107,53 @@ jobs:
 
     steps:
       - checkout
-      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/tracer-benchmark
-      - run: ~/tracer-benchmark/scripts/ci_setup.sh
-      # install the LS tracer
+      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
+      - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
-      - run: pytest --client_name python-cpp ~/tracer-benchmark/test_client.py
+      - run: pytest --client_name python ~/benchmark/test_client.py
       - store_artifacts:
           path: logs
           destination: logs
 
-  # make_graphs:
-  #   docker:
-  #     - image: circleci/python:3.7.4
-  #   working_directory: ~/repo
-  #
-  #   steps:
-  #     - run: cd ~; git clone https://github.com/isaaczinda/tracer-benchmark.git repo
-  #     - run: ./scripts/ci_setup.sh
-  #     - attach_workspace:
-  #         at: ~/plugin
-  #     - run: sudo pip install ~/plugin/*.whl
-  #     - run: mkdir graphs
-  #     - run: python cpu_graphs.py python-cpp --runtime 10 --trials 10
-  #     - run: python memory_graphs.py python-cpp
-  #     - run: python dropped_graphs.py python-cpp
-  #     - run: python disconnect_graphs.py python-cpp
-  #
-  #     - store_artifacts:
-  #         path: logs
-  #         destination: logs
-  #     - store_artifacts:
-  #         path: graphs
-  #         destination: graphs
+  make_cpu_graphs:
+    docker:
+      - image: circleci/python:3.7.4
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
+      - run: ~/benchmark/scripts/ci_setup.sh
+      - run: sudo pip install -e ~/repo
+      - run: mkdir ~/benchmark/graphs
+      - run: python ~/benchmark/cpu_graphs.py python --runtime 10 --trials 10
+      - store_artifacts:
+          path: ~/benchmark/graphs
+          destination: graphs
+      - store_artifacts:
+          path: ~/benchmark/logs
+          destination: logs
+
+  make_other_graphs:
+    docker:
+      - image: circleci/python:3.7.4
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
+      - run: ~/benchmark/scripts/ci_setup.sh
+      - run: sudo pip install -e ~/repo
+      - run: mkdir ~/benchmark/graphs
+      - run: python ~/benchmark/dropped_graphs.py python
+      - run: python ~/benchmark/memory_graphs.py python
+      - run: python ~/benchmark/disconnect_graphs.py python
+      - store_artifacts:
+          path: ~/benchmark/graphs
+          destination: graphs
+      - store_artifacts:
+          path: ~/benchmark/logs
+          destination: logs
 
 workflows:
   version: 2
@@ -150,3 +165,11 @@ workflows:
       - test-python3.6
       - test-python3.7
       - regression_test
+      - approve_make_graphs:
+          type: approval
+      - make_other_graphs:
+          requires:
+            - approve_make_graphs
+      - make_cpu_graphs:
+          requires:
+            - approve_make_graphs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - run: git clone https://github.com/isaaczinda/tracer-benchmark.git ~/benchmark
       - run: ~/benchmark/scripts/ci_setup.sh
       - run: sudo pip install -e ~/repo
-      - run: pytest --client_name python ~/benchmark/test_client.py
+      - run: pytest -s --client_name python ~/benchmark/test_client.py
       - store_artifacts:
           path: logs
           destination: logs

--- a/ci/clone_lightstep_benchmarks.sh
+++ b/ci/clone_lightstep_benchmarks.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+REPO_URL="https://github.com/lightstep/lightstep-benchmarks.git"
+MAJOR_VERSION="0"
+MINOR_VERSION="1"
+
+# clone the repo
+git clone ${REPO_URL}
+cd lightstep-benchmarks
+
+# checkout the newest commit whose tag matches the specified major / minor
+# version
+MATCHING_VERSIONS=`git tag --sort -version:refname --list "v${MAJOR_VERSION}.${MINOR_VERSION}.*"`
+NEWEST_VERSION=`echo ${MATCHING_VERSIONS} | tr '\n' ',' | cut -d ',' -f 1`
+
+git checkout ${NEWEST_VERSION}


### PR DESCRIPTION
[Depends on [lightstep benchmarks](https://github.com/lightstep/lightstep-benchmarks)]

 * Add regression_test job to CI to perform rudimentary performance checks on the tracer on each commit
 * Add make_cpu_graphs, make_dropped_graphs, make_memory_graphs, and make_disconnect_graphs which generate graphs illustrating the tracer's performance. These jobs only run when manually approved because they take ~20 minutes.
 * Fix indentation in CI config