### PR TITLE
format tracebacks with cause

### DIFF
--- a/lightstep/recorder.py
+++ b/lightstep/recorder.py
@@ -14,7 +14,7 @@ import traceback
 import warnings
 
 from basictracer.recorder import SpanRecorder
-from opentracing.logs import ERROR_KIND, STACK
+from opentracing.logs import ERROR_KIND, STACK, ERROR_OBJECT
 
 from lightstep.http_converter import HttpConverter
 from lightstep.thrift_converter import ThriftConverter
@@ -171,7 +171,11 @@ class Recorder(SpanRecorder):
                 log.key_values[ERROR_KIND] = util._format_exc_type(log.key_values[ERROR_KIND])
 
             if STACK in log.key_values:
-                log.key_values[STACK] = util._format_exc_tb(log.key_values[STACK])
+                log.key_values[STACK] = util._format_exc_tb(
+                    log.key_values.get(ERROR_OBJECT),
+                    log.key_values.get(ERROR_KIND),
+                    log.key_values[STACK]
+                )
 
         return log
 

--- a/lightstep/util.py
+++ b/lightstep/util.py
@@ -105,9 +105,9 @@ def _coerce_to_unicode(val):
             return '(encoding error)'
 
 
-def _format_exc_tb(exc_tb):
+def _format_exc_tb(exc_value, exc_type, exc_tb):
     if type(exc_tb) is types.TracebackType:
-        return ''.join(traceback.format_tb(exc_tb))
+        return ''.join(traceback.format_exception(exc_value, exc_type, exc_tb))
 
     return exc_tb
 


### PR DESCRIPTION
closes #99

Here is a script that shows how this changes the traceback formatting:

```
import sys
import traceback


try:
    try:
        raise ValueError("some value")
    except ValueError:
        raise TypeError("some type")
except Exception:
    exc_value, exc_type, exc_tb = sys.exc_info()
    print("".join(traceback.format_tb(exc_tb)))
    print("=" * 80)
    print("".join(traceback.format_exception(None, exc_type, exc_tb)))
    print("=" * 80)
    print("".join(traceback.format_exception(exc_value, None, exc_tb)))
    print("=" * 80)
    print("".join(traceback.format_exception(exc_value, exc_type, exc_tb)))
```

Output:
```
$ python foo.py 
  File "foo.py", line 9, in <module>
    raise TypeError("some type")

================================================================================
Traceback (most recent call last):
  File "foo.py", line 7, in <module>
    raise ValueError("some value")
ValueError: some value

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "foo.py", line 9, in <module>
    raise TypeError("some type")
TypeError: some type

================================================================================
Traceback (most recent call last):
  File "foo.py", line 9, in <module>
    raise TypeError("some type")
NoneType: None

================================================================================
Traceback (most recent call last):
  File "foo.py", line 7, in <module>
    raise ValueError("some value")
ValueError: some value

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "foo.py", line 9, in <module>
    raise TypeError("some type")
TypeError: some type
```