### PR TITLE
Revert "format tracebacks with cause (#100)"

### DIFF
--- a/lightstep/recorder.py
+++ b/lightstep/recorder.py
@@ -14,7 +14,7 @@ import traceback
 import warnings
 
 from basictracer.recorder import SpanRecorder
-from opentracing.logs import ERROR_KIND, STACK, ERROR_OBJECT
+from opentracing.logs import ERROR_KIND, STACK
 
 from lightstep.http_converter import HttpConverter
 from lightstep.thrift_converter import ThriftConverter
@@ -171,11 +171,7 @@ class Recorder(SpanRecorder):
                 log.key_values[ERROR_KIND] = util._format_exc_type(log.key_values[ERROR_KIND])
 
             if STACK in log.key_values:
-                log.key_values[STACK] = util._format_exc_tb(
-                    log.key_values.get(ERROR_OBJECT),
-                    log.key_values.get(ERROR_KIND),
-                    log.key_values[STACK]
-                )
+                log.key_values[STACK] = util._format_exc_tb(log.key_values[STACK])
 
         return log
 

--- a/lightstep/util.py
+++ b/lightstep/util.py
@@ -105,9 +105,9 @@ def _coerce_to_unicode(val):
             return '(encoding error)'
 
 
-def _format_exc_tb(exc_value, exc_type, exc_tb):
+def _format_exc_tb(exc_tb):
     if type(exc_tb) is types.TracebackType:
-        return ''.join(traceback.format_exception(exc_value, exc_type, exc_tb))
+        return ''.join(traceback.format_tb(exc_tb))
 
     return exc_tb
 


### PR DESCRIPTION
This reverts commit 1c945209689be023cd4a7d3634ff3148a8e064a3 introduced in PR https://github.com/lightstep/lightstep-tracer-python/pull/100

This fails with `AttributeError: 'str' object has no attribute '__cause__'` in production for us. I'll look more deeply into why this happened later but for now this should fix the bleeding.